### PR TITLE
check if articles are selected for download

### DIFF
--- a/copy_this/modules/jxmods/oxprobs/application/controllers/admin/oxprobs_articles.php
+++ b/copy_this/modules/jxmods/oxprobs/application/controllers/admin/oxprobs_articles.php
@@ -117,6 +117,9 @@ echo '</pre>';/**/
         $aArticles = $this->_decodeHtmlSpecialChars($aArticles);
 
         $aSelOxid = $this->getConfig()->getRequestParameter( 'oxprobs_oxid' ); 
+        if(!$aSelOxid){
+            return;
+        }
         
         $sContent = '';
         if ( $myConfig->getConfigParam("bOxProbsHeader") ) {


### PR DESCRIPTION
If no article is selected and you click on "download", you will get a php warning for the line: "if ( in_array($aArticle['oxid'], $aSelOxid) ) {".
Warning: in_array() expects parameter 2 to be array, null given.

So I check if we have selected some articles.